### PR TITLE
feat(lunox-core): export console related modules to @lunoxjs/core/console

### DIFF
--- a/packages/lunox-core/console.d.ts
+++ b/packages/lunox-core/console.d.ts
@@ -1,0 +1,1 @@
+export * from "./dist/Console";

--- a/packages/lunox-core/package.json
+++ b/packages/lunox-core/package.json
@@ -13,12 +13,16 @@
     "./build": "./dist/build/index.mjs",
     "./helpers": "./dist/helpers.mjs",
     "./contracts": "./dist/Contracts/index.d.ts",
-    "./facades": "./dist/Support/Facades/index.mjs"
+    "./facades": "./dist/Support/Facades/index.mjs",
+    "./console": "./dist/Console/index.mjs"
   },
   "files": [
     "dist/*",
     "global.d.ts",
     "build.d.ts",
+    "helpers.d.ts",
+    "contracts.d.ts",
+    "facades.d.ts",
     "stub/*"
   ],
   "scripts": {

--- a/packages/lunox-core/rollup.config.mjs
+++ b/packages/lunox-core/rollup.config.mjs
@@ -7,6 +7,7 @@ export default [
       "src/build/index.ts",
       "src/Contracts/index.ts",
       "src/Support/Facades/index.ts",
+      "src/Console/index.ts",
     ],
     {
       declaration: process.env.NODE_ENV == "production",

--- a/packages/lunox-core/src/Console/Kernel.ts
+++ b/packages/lunox-core/src/Console/Kernel.ts
@@ -44,7 +44,7 @@ class Kernel {
 
   public async handle() {
     const VERSION = JSON.parse(
-      fs.readFileSync(get_current_dir(import.meta.url) + "/../package.json", {
+      fs.readFileSync(lunox_path("../package.json"), {
         encoding: "utf-8",
       })
     ).version;

--- a/packages/lunox-core/src/Console/index.ts
+++ b/packages/lunox-core/src/Console/index.ts
@@ -1,4 +1,4 @@
-import ConsoleKernel from "./Kernel";
+import Kernel from "./Kernel";
 import Command from "./Command";
 
-export { ConsoleKernel, Command };
+export { Kernel, Command };

--- a/packages/lunox-core/src/index.ts
+++ b/packages/lunox-core/src/index.ts
@@ -5,7 +5,6 @@ export * from "./Foundation/Exception";
 export * from "./Foundation/Http";
 export * from "./Routing";
 export * from "./Support";
-export * from "./Console";
 export * from "./Session";
 export * from "./Http";
 export * from "./Cookie";

--- a/packages/lunox-eloquent/src/console/MakeMigrationCommand.ts
+++ b/packages/lunox-eloquent/src/console/MakeMigrationCommand.ts
@@ -1,4 +1,4 @@
-import { Command } from "@lunoxjs/core";
+import { Command } from "@lunoxjs/core/console";
 import fs from "fs";
 import DB from "../facades/DB";
 

--- a/packages/lunox-eloquent/src/console/MakeModelCommand.ts
+++ b/packages/lunox-eloquent/src/console/MakeModelCommand.ts
@@ -1,4 +1,5 @@
-import { Command, Str } from "@lunoxjs/core";
+import { Str } from "@lunoxjs/core";
+import { Command } from "@lunoxjs/core/console";
 import fs from "fs";
 import path from "path";
 import DB from "../facades/DB";

--- a/packages/lunox-eloquent/src/console/MakeSeederCommand.ts
+++ b/packages/lunox-eloquent/src/console/MakeSeederCommand.ts
@@ -1,4 +1,4 @@
-import { Command } from "@lunoxjs/core";
+import { Command } from "@lunoxjs/core/console";
 import fs from "fs";
 import path from "path";
 

--- a/packages/lunox-eloquent/src/console/RefreshMigrationCommand.ts
+++ b/packages/lunox-eloquent/src/console/RefreshMigrationCommand.ts
@@ -1,4 +1,4 @@
-import { Command } from "@lunoxjs/core";
+import { Command } from "@lunoxjs/core/console";
 import DB from "../facades/DB";
 
 class RefreshMigrationCommand extends Command {

--- a/packages/lunox-eloquent/src/console/ResetMigrationCommand.ts
+++ b/packages/lunox-eloquent/src/console/ResetMigrationCommand.ts
@@ -1,4 +1,4 @@
-import { Command } from "@lunoxjs/core";
+import { Command } from "@lunoxjs/core/console";
 import DB from "../facades/DB";
 
 class ResetMigrationCommand extends Command {

--- a/packages/lunox-eloquent/src/console/RollbackMigrationCommand.ts
+++ b/packages/lunox-eloquent/src/console/RollbackMigrationCommand.ts
@@ -1,4 +1,4 @@
-import { Command } from "@lunoxjs/core";
+import { Command } from "@lunoxjs/core/console";
 import DB from "../facades/DB";
 
 class RollbackMigrationCommand extends Command {

--- a/packages/lunox-eloquent/src/console/RunMigrationCommand.ts
+++ b/packages/lunox-eloquent/src/console/RunMigrationCommand.ts
@@ -1,4 +1,4 @@
-import { Command } from "@lunoxjs/core";
+import { Command } from "@lunoxjs/core/console";
 import DB from "../facades/DB";
 
 class RunMigrationCommand extends Command {

--- a/packages/lunox-eloquent/src/console/RunSeederCommand.ts
+++ b/packages/lunox-eloquent/src/console/RunSeederCommand.ts
@@ -1,4 +1,4 @@
-import { Command } from "@lunoxjs/core";
+import { Command } from "@lunoxjs/core/console";
 import { pathToFileURL } from "url";
 import DB from "../facades/DB";
 import type Seeder from "../Seeder";

--- a/presets/api/app/Console/Command/Test.ts
+++ b/presets/api/app/Console/Command/Test.ts
@@ -1,4 +1,4 @@
-import { Command } from "@lunoxjs/core";
+import { Command } from "@lunoxjs/core/console";
 class TestCommand extends Command {
   protected signature = "test";
   protected description = "testing artisan command";

--- a/presets/api/app/Console/Kernel.ts
+++ b/presets/api/app/Console/Kernel.ts
@@ -1,4 +1,4 @@
-import { ConsoleKernel } from "@lunoxjs/core";
+import { Kernel as ConsoleKernel } from "@lunoxjs/core/console";
 
 class Kernel extends ConsoleKernel {
   protected async commands() {

--- a/presets/react/app/Console/Command/Test.ts
+++ b/presets/react/app/Console/Command/Test.ts
@@ -1,4 +1,4 @@
-import { Command } from "@lunoxjs/core";
+import { Command } from "@lunoxjs/core/console";
 class TestCommand extends Command {
   protected signature = "test";
   protected description = "testing artisan command";

--- a/presets/react/app/Console/Kernel.ts
+++ b/presets/react/app/Console/Kernel.ts
@@ -1,4 +1,4 @@
-import { ConsoleKernel } from "@lunoxjs/core";
+import { Kernel as ConsoleKernel } from "@lunoxjs/core/console";
 
 class Kernel extends ConsoleKernel {
   protected async commands() {

--- a/presets/svelte/app/Console/Command/Test.ts
+++ b/presets/svelte/app/Console/Command/Test.ts
@@ -1,4 +1,4 @@
-import { Command } from "@lunoxjs/core";
+import { Command } from "@lunoxjs/core/console";
 class TestCommand extends Command {
   protected signature = "test";
   protected description = "testing artisan command";

--- a/presets/svelte/app/Console/Kernel.ts
+++ b/presets/svelte/app/Console/Kernel.ts
@@ -1,4 +1,4 @@
-import { ConsoleKernel } from "@lunoxjs/core";
+import { Kernel as ConsoleKernel } from "@lunoxjs/core/console";
 
 class Kernel extends ConsoleKernel {
   protected async commands() {


### PR DESCRIPTION
All module related to console application now exported to `@lunoxjs/core/console`. 
example: 
```ts
// before
import { Command, ConsoleKernel } from "@lunoxjs/core"

// after 
import { Command, Kernel } from "@lunoxjs/core/console"
```