### PR TITLE
fix(lunox-core): form upload single file should not be array

### DIFF
--- a/packages/lunox-core/src/Foundation/Http/Kernel.ts
+++ b/packages/lunox-core/src/Foundation/Http/Kernel.ts
@@ -515,6 +515,10 @@ const parseFormData = async (req: ServerRequest, request: Request) => {
     (prev, key) => {
       const file = files[key];
       if (!file) return prev;
+      if(!key.endsWith("[]") && file.length == 1){
+        prev[key] = new UploadedFile(file[0]);
+        return prev;
+      }
       // this to ensure the behaviour consistent with reqular request body
       if (key.endsWith("[]")) {
         key = key.replace("[]", "");


### PR DESCRIPTION
On same case, for example when uploading using inertia form. The submitted file become array of UploadedFile even the upload is single file